### PR TITLE
Add Windows support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,9 @@ function FindClosestPyProjectTomlInPath(pythonFile: string, workspaceRoot: strin
 }
 
 async function setPythonInterpreter(poetryPath: string, poetryPackagePath: string, pythonExtension: VscodePython.PythonExtension, workspaceFolder: vscode.WorkspaceFolder) {
-    const pythonInterpreterPath = path.join(poetryPath, '.venv', 'bin', 'python');
+    const binDir = process.platform === 'win32' ? 'Scripts' : 'bin';
+    const pythonExecutable = process.platform === 'win32' ? 'python.exe' : 'python';
+    const pythonInterpreterPath = path.join(poetryPath, '.venv', binDir, pythonExecutable);
     // const currentDefaultInterpreter = vscode.workspace.getConfiguration('python').get('defaultInterpreterPath')
     // const currentInterpreter = vscode.extensions.getExtension('ms-python.python')?.exports.environments.getActiveEnvironmentPath().path
     const currentInterpreter = pythonExtension.environments.getActiveEnvironmentPath().path


### PR DESCRIPTION
The extension currently hard-codes path to Python interpreter following Unix convention.

This PR adds Windows support by making Python interpreter path dynamic based on current OS.